### PR TITLE
Scrape timestamp from new VF website format

### DIFF
--- a/api.js
+++ b/api.js
@@ -69,8 +69,8 @@ function getLocationFromVF(mmsi, cb) {
       const latitude = splitted[0].indexOf('N') === -1 ? parseFloat(splitted[0]) * -1 : parseFloat(splitted[0]);
       const longitude = splitted[1].indexOf('E') === -1 ? parseFloat(splitted[1]) * -1 : parseFloat(splitted[1]);
 
-      const timestamp = new Date($('.vfix-top:nth-of-type(1) .tparams tr:nth-of-type(11) .v3').text()).toString();
-      const unixtime = new Date($('.vfix-top:nth-of-type(1) .tparams tr:nth-of-type(11) .v3').text()).getTime()/1000;
+      const timestamp = new Date($('#lastrep').attr('data-title')).toString();
+      const unixtime = new Date(timestamp).getTime()/1000;
 
       cb(
         parsePosition({


### PR DESCRIPTION
Fixes one half of #8: scraping from the new VF website. Scraping MT is still broken, and needs to be addressed in a separate PR.

**Before**
```
$ node index.js 
Node app is running on port 5000
getLocationFromVF https://www.vesselfinder.com/vessels/somestring-MMSI-211281610
Extracted:  39.86162 N/0.06946 W  0.0 261.0
Position:  { error: null,
  data:
   { timestamp: 'Invalid Date',
     unixtime: NaN,
     course: '261.0',
     speed: '0.0',
     latitude: 39.86162,
     longitude: -0.06946 } }
```

**After**
```
$ node index.js 
Node app is running on port 5000
getLocationFromVF https://www.vesselfinder.com/vessels/somestring-MMSI-211281610
Extracted:  39.86162 N/0.06946 W  0.0 261.0
Position:  { error: null,
  data:
   { timestamp:
      'Thu Jan 30 2020 22:30:00 GMT+0100 (Central European Standard Time)',
     unixtime: 1580419800,
     course: '261.0',
     speed: '0.0',
     latitude: 39.86162,
     longitude: -0.06946 } }
```