### PR TITLE
Added getVesselsInPort - Fixed headers (again) - Fixed bug in MT when speed=0 or course=0 - Links in index.html made relative

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,18 @@
+name: publish npm package
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10
+      - run: npm install
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}

--- a/api.js
+++ b/api.js
@@ -25,7 +25,16 @@ function parsePosition(position) {
   }
 }
 
-const headers = {
+const headersVF = {
+  'User-Agent': 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3703.0 Safari/537.36',
+  'Content-Type' : 'application/x-www-form-urlencoded',
+  'cache-control': 'max-age=0',
+  'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3',
+  'upgrade-insecure-requests':1,
+  'accept-language': 'en-GB,en-US;q=0.9,en;q=0.8'
+};
+
+const headersMT = {
   //'User-Agent': 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3703.0 Safari/537.36',
   'Content-Type' : 'application/x-www-form-urlencoded',
   'cache-control': 'max-age=0',
@@ -37,6 +46,8 @@ const headers = {
 function getLocationFromVF(mmsi, cb) {
   const url = `https://www.vesselfinder.com/vessels/somestring-MMSI-${mmsi}`;
   debug('getLocationFromVF', url);
+
+  headers = headersVF;
 
   const options = {
     url,
@@ -68,7 +79,7 @@ function getLocationFromVF(mmsi, cb) {
       const latitude = splitted[0].indexOf('N') === -1 ? parseFloat(splitted[0]) * -1 : parseFloat(splitted[0]);
       const longitude = splitted[1].indexOf('E') === -1 ? parseFloat(splitted[1]) * -1 : parseFloat(splitted[1]);
 
-      const timestamp = new Date($('#lastrep').attr('data-title')).toString();
+      const timestamp = new Date($('#lastrep').attr('data-title')).toISOString();
       const unixtime = new Date(timestamp).getTime()/1000;
 
       cb(
@@ -95,6 +106,8 @@ function getLocationFromVF(mmsi, cb) {
 function getLocationFromMT(mmsi, cb) {
   const url = `https://www.marinetraffic.com/en/data/?asset_type=vessels&columns=flag,shipname,photo,recognized_next_port,reported_eta,reported_destination,current_port,imo,mmsi,ship_type,show_on_live_map,time_of_latest_position,lat_of_latest_position,lon_of_latest_position&mmsi|eq|mmsi=${mmsi}`;
   debug('getLocationFromMT', url);
+
+  headers = headersMT;
 
   const options = {
     url,
@@ -133,7 +146,7 @@ function getLocationFromMT(mmsi, cb) {
               const speed = parseFloat(parsed.data[0].SPEED);
               const course = parseFloat(parsed.data[0].COURSE);
 
-              const timestamp = new Date(parsed.data[0].LAST_POS*1000).toString();
+              const timestamp = new Date(parsed.data[0].LAST_POS*1000).toISOString();
               const unixtime = new Date(parsed.data[0].LAST_POS*1000).getTime()/1000;
               console.log(123);
 
@@ -176,7 +189,7 @@ function getLocationFromMT(mmsi, cb) {
 }
 
 function getLocation(mmsi, cb) {
-  debug('getting location for vehicle: ', mmsi);
+  debug('getting location for vessel: ', mmsi);
   getLocationFromVF(mmsi, function(VFResult) {
     debug('got location from vf', VFResult);
 
@@ -188,7 +201,7 @@ function getLocation(mmsi, cb) {
         if(!VFResult.data){
           return cb(MTResult);
         }
-        const vfDate = moment(VFResult.data.timestamp);
+        const vfDate = moment( VFResult.data.timestamp);
         const mtDate = moment(MTResult.data.timestamp);
         const secondsDiff = mtDate.diff(vfDate, 'seconds')
         debug('time diff in seconds: ', secondsDiff);

--- a/api.js
+++ b/api.js
@@ -28,7 +28,7 @@ function parsePosition(position) {
 
 const headers = {
   'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3703.0 Safari/537.36',
- // 'Content-Type' : 'application/x-www-form-urlencoded',
+  'Content-Type' : 'application/x-www-form-urlencoded',
   'cache-control': 'max-age=0',
   'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3',
   'upgrade-insecure-requests':1,
@@ -147,7 +147,7 @@ function getLocationFromMT(mmsi, cb) {
               //const $ = cheerio.load(html);
               console.log(timestamp, speed ,course ,latitude ,longitude)
 
-              if (timestamp && speed && course && latitude && longitude) {
+              if (timestamp && latitude && longitude) {
                 cb(
                   parsePosition({
                     error: null,

--- a/api.js
+++ b/api.js
@@ -1,6 +1,7 @@
 const cheerio = require('cheerio');
 const moment = require('moment');
 const request = require('request');
+var brotli = require('brotli');
 
 const debug = (...args) => {
   if (true) {
@@ -25,29 +26,20 @@ function parsePosition(position) {
   }
 }
 
-const headersVF = {
-  'User-Agent': 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3703.0 Safari/537.36',
-  'Content-Type' : 'application/x-www-form-urlencoded',
+const headers = {
+  'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3703.0 Safari/537.36',
+ // 'Content-Type' : 'application/x-www-form-urlencoded',
   'cache-control': 'max-age=0',
   'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3',
   'upgrade-insecure-requests':1,
   'accept-language': 'en-GB,en-US;q=0.9,en;q=0.8'
 };
 
-const headersMT = {
-  //'User-Agent': 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3703.0 Safari/537.36',
-  'Content-Type' : 'application/x-www-form-urlencoded',
-  'cache-control': 'max-age=0',
-  'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3',
-  'upgrade-insecure-requests':1,
-  'accept-language': 'en-GB,en-US;q=0.9,en;q=0.8'
-};
 
 function getLocationFromVF(mmsi, cb) {
   const url = `https://www.vesselfinder.com/vessels/somestring-MMSI-${mmsi}`;
   debug('getLocationFromVF', url);
 
-  headers = headersVF;
 
   const options = {
     url,
@@ -107,7 +99,6 @@ function getLocationFromMT(mmsi, cb) {
   const url = `https://www.marinetraffic.com/en/data/?asset_type=vessels&columns=flag,shipname,photo,recognized_next_port,reported_eta,reported_destination,current_port,imo,mmsi,ship_type,show_on_live_map,time_of_latest_position,lat_of_latest_position,lon_of_latest_position&mmsi|eq|mmsi=${mmsi}`;
   debug('getLocationFromMT', url);
 
-  headers = headersMT;
 
   const options = {
     url,
@@ -127,7 +118,10 @@ function getLocationFromMT(mmsi, cb) {
       secondRequestHeaders.referer = `https://www.marinetraffic.com/en/data/?asset_type=vessels&columns=flag,shipname,photo,recognized_next_port,reported_eta,reported_destination,current_port,imo,mmsi,ship_type,show_on_live_map,time_of_latest_position,lat_of_latest_position,lon_of_latest_position&mmsi|eq|mmsi=${mmsi}`;
       secondRequestHeaders['Vessel-Image'] = '007fb60815c6558c472a846479502b668e08';
 
-      request({ url: `https://www.marinetraffic.com/en/reports?asset_type=vessels&columns=flag,shipname,photo,recognized_next_port,reported_eta,reported_destination,current_port,imo,mmsi,ship_type,show_on_live_map,time_of_latest_position,lat_of_latest_position,lon_of_latest_position&mmsi=${mmsi}`, headers:secondRequestHeaders},function(error, response, html){
+      request({
+        url: `https://www.marinetraffic.com/en/reports?asset_type=vessels&columns=flag,shipname,photo,recognized_next_port,reported_eta,reported_destination,current_port,imo,mmsi,ship_type,show_on_live_map,time_of_latest_position,lat_of_latest_position,lon_of_latest_position&mmsi=${mmsi}`,
+        headers: secondRequestHeaders
+      }, function (error, response, html) {
 
         if (!error && response.statusCode == 200 || response.statusCode == 403) {
 
@@ -190,15 +184,15 @@ function getLocationFromMT(mmsi, cb) {
 
 function getLocation(mmsi, cb) {
   debug('getting location for vessel: ', mmsi);
-  getLocationFromVF(mmsi, function(VFResult) {
+  getLocationFromVF(mmsi, function (VFResult) {
     debug('got location from vf', VFResult);
 
-    getLocationFromMT(mmsi, function(MTResult) {
-      if(MTResult.error){
+    getLocationFromMT(mmsi, function (MTResult) {
+      if (MTResult.error) {
         cb(VFResult);
-      }else{
+      } else {
         debug('got location from mt', MTResult);
-        if(!VFResult.data){
+        if (!VFResult.data) {
           return cb(MTResult);
         }
         const vfDate = moment( VFResult.data.timestamp);
@@ -212,8 +206,60 @@ function getLocation(mmsi, cb) {
   });
 }
 
+function getVesselsInPort(shipPort, cb) {
+  const url = `https://www.marinetraffic.com/en/reports?asset_type=vessels&columns=flag,shipname,photo,recognized_next_port,reported_eta,reported_destination,current_port,imo,ship_type,show_on_live_map,time_of_latest_position,lat_of_latest_position,lon_of_latest_position,current_port_country,notes&current_port_in_name=${shipPort}`;
+  debug('getVesselsInPort', url);
+
+  const headers={
+  'accept': '*/*',
+  'Accept-Language': 'en-US,en;q=0.5',
+  'Accept-Encoding': 'gzip, deflate, brotli',
+  'Vessel-Image': '0053e92efe9e7772299d24de2d0985adea14',
+  'X-Requested-With': 'XMLHttpRequest'
+}
+  const options = {
+    url,
+    headers,
+    json: true,
+    gzip: true,
+    deflate: true,
+    brotli:true
+   };
+  request(options, function (error, response, html) {
+    if (!error && response.statusCode == 200 || typeof response != 'undefined' && response.statusCode == 403) {
+
+
+    return cb(response.body.data.map((vessel) => ({
+      name: vessel.SHIPNAME,
+      id: vessel.SHIP_ID,
+      lat: Number(vessel.LAT),
+      lon: Number(vessel.LON),
+      timestamp: vessel.LAST_POS,
+      mmsi: vessel.MMSI,
+      imo: vessel.IMO,
+      callsign: vessel.CALLSIGN,
+      speed: Number(vessel.SPEED),
+      area: vessel.AREA_CODE,
+      type: vessel.TYPE_SUMMARY,
+      country: vessel.COUNTRY,
+      destination: vessel.DESTINATION,
+      port_current_id: vessel.PORT_ID,
+      port_current: vessel.CURRENT_PORT,
+      port_next_id: vessel.NEXT_PORT_ID,
+      port_next: vessel.NEXT_PORT_NAME,
+    })));      
+    } else {
+      debug('error in getVesselsInPort');
+      cb({ error: 'an unknown error occured' });
+      return false;
+    }
+  });
+}
+
+
 module.exports = {
   getLocationFromVF: getLocationFromVF,
   getLocationFromMT: getLocationFromMT,
   getLocation: getLocation,
+  getVesselsInPort:getVesselsInPort,
 };

--- a/index.html
+++ b/index.html
@@ -35,6 +35,10 @@ example: <a href="http://localhost:5000/getVesselsInArea/WMED,EMED">http://local
   port_next: vessel.NEXT_PORT_NAME,
 },…]
 </code></pre>
+<h4>/getVesselsInPort/:shipPort</h4>
+<p>Returns all vessels in a port, named after the MT nomenclature
+example: <a href="http://localhost:5000/getVesselsInPort/piraeus">http://localhost:5000/getVesselsInPort/piraeus</a><br>
+Output format identical to <b>getVesselsInArea</b></p>
 <h2>Install on local machine</h2>
 <p>Requirements: npm &#x26; nodejs.</p>
 <ol>

--- a/index.html
+++ b/index.html
@@ -5,16 +5,16 @@
 <h3>Paths</h3>
 <h4>/getLastPosition/:mmsi</h4>
 <p>Takes position from MT and from VT and returns the newest
-example: <a href="http://localhost:5000/getLastPosition/211281610">http://localhost:5000/getLastPosition/211281610</a></p>
+example: <a href="/getLastPosition/211281610">http://host:port/getLastPosition/211281610</a></p>
 <h4>/getLastPositionFromVF/:mmsi</h4>
 <p>Returns position from VF
-example: <a href="http://localhost:5000/getLastPositionFromVF/211281610">http://localhost:5000/getLastPositionFromVF/211281610</a></p>
+example: <a href="/getLastPositionFromVF/211281610">http://host:port/getLastPositionFromVF/211281610</a></p>
 <h4>/getLastPositionFromMT/:mmsi</h4>
 <p>Returns position from MT
-example: <a href="http://localhost:5000/getLastPositionFromMT/211281610">http://localhost:5000/getLastPositionFromMT/211281610</a></p>
+example: <a href="/getLastPositionFromMT/211281610">http://host:port/getLastPositionFromMT/211281610</a></p>
 <h4>/getVesselsInArea/:area</h4>
 <p>Returns all vessels in area, defined by a list of area keywords
-example: <a href="http://localhost:5000/getVesselsInArea/WMED,EMED">http://localhost:5000/getVesselsInArea/WMED,EMED</a></p>
+example: <a href="/getVesselsInArea/WMED,EMED">http://host:port/getVesselsInArea/WMED,EMED</a></p>
 <pre><code class="language-Javascript">[{
   name: vessel.SHIPNAME,
   id: vessel.SHIP_ID,
@@ -37,7 +37,7 @@ example: <a href="http://localhost:5000/getVesselsInArea/WMED,EMED">http://local
 </code></pre>
 <h4>/getVesselsInPort/:shipPort</h4>
 <p>Returns all vessels in a port, named after the MT nomenclature
-example: <a href="http://localhost:5000/getVesselsInPort/piraeus">http://localhost:5000/getVesselsInPort/piraeus</a><br>
+example: <a href="/getVesselsInPort/piraeus">http://host:port/getVesselsInPort/piraeus</a><br>
 Output format identical to <b>getVesselsInArea</b></p>
 <h2>Install on local machine</h2>
 <p>Requirements: npm &#x26; nodejs.</p>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 example: <a href="http://localhost:5000/getLastPosition/211281610">http://localhost:5000/getLastPosition/211281610</a></p>
 <h4>/getLastPositionFromVF/:mmsi</h4>
 <p>Returns position from VF
-example: <a href="http://localhost:5000/getLastPositionFromVF/">http://localhost:5000/getLastPositionFromVF/</a></p>
+example: <a href="http://localhost:5000/getLastPositionFromVF/211281610">http://localhost:5000/getLastPositionFromVF/211281610</a></p>
 <h4>/getLastPositionFromMT/:mmsi</h4>
 <p>Returns position from MT
 example: <a href="http://localhost:5000/getLastPositionFromMT/211281610">http://localhost:5000/getLastPositionFromMT/211281610</a></p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -274,6 +274,11 @@
         }
       }
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -368,6 +373,14 @@
             "is-extendable": "^0.1.0"
           }
         }
+      }
+    },
+    "brotli": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.2.tgz",
+      "integrity": "sha1-UlqcrU/LqWR119OI9q7LE+7VL0Y=",
+      "requires": {
+        "base64-js": "^1.1.2"
       }
     },
     "buffer-crc32": {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "ais scraping script",
   "main": "server.js",
   "dependencies": {
+    "brotli": "^1.3.2",
     "cheerio": "^1.0.0-rc.2",
-    "moment": "^2.29.1",
     "express": "^4.17.1",
+    "moment": "^2.29.1",
     "puppeteer": "^1.20.0",
     "request": "^2.88.2",
     "tor-request": "^2.3.1"

--- a/readme.md
+++ b/readme.md
@@ -1,28 +1,34 @@
-AIS API
-=======
+# AIS API
+
 I looked for a free API solution to access machine readable AIS Data. This solution uses the free web solutions to crawl the data and returns them in json.
 
 ## How to use
+
 This is a nodejs web app.
 
 ### Paths
 
 #### /getLastPosition/:mmsi
+
 Takes position from MT and from VT and returns the newest
 example: http://localhost:5000/getLastPosition/211281610
 
 #### /getLastPositionFromVF/:mmsi
+
 Returns position from VF
-example: http://localhost:5000/getLastPositionFromVF/
+example: http://localhost:5000/getLastPositionFromVF/211281610
 
 #### /getLastPositionFromMT/:mmsi
+
 Returns position from MT
 example: http://localhost:5000/getLastPositionFromMT/211281610
 
 #### /getVesselsInArea/:area
+
 Returns all vessels in area, defined by a list of area keywords
 example: http://localhost:5000/getVesselsInArea/WMED,EMED
-``` Javascript
+
+```Javascript
 [{
   name: vessel.SHIPNAME,
   id: vessel.SHIP_ID,
@@ -54,14 +60,13 @@ Requirements: npm & nodejs.
 
 3. run `node index.js`
 
-## Install as docker container  
-  
-Requirements: docker  
+## Install as docker container
 
-1. `docker build -t ais-api .`  
+Requirements: docker
 
-2. `docker run -p 5000:5000 ais-api`  
+1. `docker build -t ais-api .`
 
+2. `docker run -p 5000:5000 ais-api`
 
 ## Deploy to heroku
 

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,13 @@ example: http://localhost:5000/getVesselsInArea/WMED,EMED
 },…]
 ```
 
+#### /getVesselsInPort/:shipPort
+
+Returns all vessels in a port, named after the MT nomenclature
+example: http://localhost:5000/getVesselsInPort/piraeus
+
+Output format identical to **getVesselsInArea**
+
 ## Install on local machine
 
 Requirements: npm & nodejs.

--- a/server.js
+++ b/server.js
@@ -38,6 +38,12 @@ function init() {
     });
   });
 
+  app.get('/getVesselsInPort/:shipPort', (req, res) => {
+    api.getVesselsInPort(req.params.shipPort, (result) => {
+      res.send(result);
+    });
+  });  
+
   app.listen(app.get('port'), function() {
     console.log('Node app is running on port', app.get('port'));
   });


### PR DESCRIPTION
1. Added getVesselsInPort, parameter :shipPort  accepts values (literals) from MT list of ports. It is an MT-only request.

2. Headers again made common for both VF and MT.  The previous problem was due to an incorrect entry for the 'User-agent' value. It contained the invalid substring 'user-agent: '. Corrected the value as following:
`'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3703.0 Safari/537.36'`

3. getLocationFromMT rejected responses when speed=0 or course=0 in the following statement:
`    if (timestamp && speed && course && latitude && longitude)` 
It was changed to:
`    if (timestamp && latitude && longitude)` 

4.  Request href links in index.html were made relative to make experimentation easy wherever the service runs